### PR TITLE
bump tari_crypto version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_crypto = "0.19.0"
+tari_crypto = "0.20.0"


### PR DESCRIPTION
the version we use is now 0.20.0 on the tari repo